### PR TITLE
Move %hookf match before %hook

### DIFF
--- a/Logos.tmLanguage
+++ b/Logos.tmLanguage
@@ -15,7 +15,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>%(init|hook|subclass|group|class|new|ctor|end|config|orig|log|hookf|dtor|property|c)</string>
+			<string>%(init|hookf|hook|subclass|group|class|new|ctor|end|config|orig|log|dtor|property|c)</string>
 			<key>name</key>
 			<string>keyword.source.logos</string>
 		</dict>


### PR DESCRIPTION
Simple change to reorder the match list. Ensures syntax highlighting properly applies to `%hookf`, rather than just the `%hook` prefix